### PR TITLE
Updates to the August 2015 Beer and Tell post

### DIFF
--- a/blog/beer_and_tell/2015-08-August.md
+++ b/blog/beer_and_tell/2015-08-August.md
@@ -15,17 +15,21 @@ affected. The check is powered by [doiuse][], and projects can add a `.doiuse`
 file (using [browserslist syntax][]) that specifies which browser versions they
 want to be tested against. Discord currently checks CSS and [Stylus][] files.
 
-The MDN team is looking for sites to test Discord out. Work on the site is
-currently suspended (which is why it's a side project, openjck and friends won't
-stop working on it) so that feedback can be gathered to determine where the site
+The Discord team ([mrmakeit][], [groovecoder][], [davidwalsh][], and
+[openjck][]) is looking for sites to test Discord out. Work on the site is
+currently suspended (which is why it's a side project, the team may work on it
+in their free time) so that feedback can be gathered to determine where the site
 should go next. If you're interested in trying out Discord, let [groovecoder][]
 know!
 
 [openjck]: https://mozillians.org/en-US/u/openjck/
-[Discord]: http://mdn-discord.herokuapp.com/
+[Discord]: https://github.com/mdn/discord
 [doiuse]: https://github.com/anandthakker/doiuse
 [browserslist syntax]: https://github.com/ai/browserslist#queries
+[Stylus]: https://learnboost.github.io/stylus/
+[mrmakeit]: https://mozillians.org/en-US/u/MrMakeIt/
 [groovecoder]: https://mozillians.org/en-US/u/groovecoder/
+[davidwalsh]: http://davidwalsh.name/
 
 ## peterbe: Activity and Fanout.io
 Next up was [peterbe][], with an update to [Activity][]. The site now uses


### PR DESCRIPTION
* Add project credits
* Add missing Stylus link
* Link the name Discord to the GitHub project page rather than the
  homepage. The two offer the same content, but the project page also
  gives visitors a chance to fork and star the project.