### PR TITLE
fix(projects.json): update localforage url

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -431,10 +431,10 @@
         {
             "name": "localForage",
             "repos": [
-                "https://github.com/mozilla/localforage"
+                "https://github.com/localForage/localForage"
             ],
             "github": {
-                "user": "mozilla",
+                "user": "localForage",
                 "repository": "localforage"
             }
         },


### PR DESCRIPTION
LocalForage has moved under its own organization and it currently appears to have 0 stargazers. Hopefully, updating the project url to the new one will fix the 0 stargazers issue.